### PR TITLE
Move helpers into utils

### DIFF
--- a/app/tweetPACs.js
+++ b/app/tweetPACs.js
@@ -1,12 +1,19 @@
 const async = require('async');
+const moment = require('moment');
+const config = require('../config');
 
 const propublicaService = require('../services/propublica');
-const config = require('../config');
 const twitterService = require('../services/twitter');
 const bitlyService = require('../services/bitly')
+
 const Vote = require('../models/vote');
 const PACContribution = require('../models/pacContribution');
-const moment = require('moment');
+
+const okayToTweet = require('../util/helpers').okayToTweet;
+const handleNullValues = require('../util/helpers').handleNullValues;
+const handleDonorName = require('../util/helpers').handleDonorName;
+const toProperCase = require('../util/helpers').toProperCase; 
+
 
 module.exports = tweetContribution = (cb) => {
     PACContribution.findOne({
@@ -35,7 +42,8 @@ module.exports = tweetContribution = (cb) => {
         twitterService.tweet(pacMessage, (err) => {
           if (err) {
             return cb(err);
-        }       
+        }
+        console.log('Tweeting PAC data:', pacMessage)       
         // save any new PAC data contribution entries to the database
         contribution.tweetedAt = new Date();
         contribution.save(cb);
@@ -47,65 +55,19 @@ module.exports = tweetContribution = (cb) => {
   })
 }
 
-// tweeting PAC contributions every 2 hours
-const okayToTweet = (contribution) => {
-  if (!contribution.tweetedAt) {
-    return true;
-  }
-  const tweetedAt = new moment(contribution.tweetedAt);
-  const cutoff = new moment().subtract(2, 'h');
-    if (tweetedAt.isBefore(cutoff)) {
-      return true;
-    }
-  return false;
-}
-
-// properCase helper
-String.prototype.toProperCase = function () {
-  return this.replace(/\w\S*/g, function(txt){return txt.charAt(0).toUpperCase() + txt.substr(1).toLowerCase();});
-}
-
-// handle null values for string methods
-const handleNullValues = (obj) => {
-  Object.keys(obj).forEach(function(key) {
-    if(obj[key] === null) {
-      obj[key] = '-';
-    }
-  })
-  return obj;
-}
-
-// to avoid 186 errors, we will have to abbreviate
-const handleDonorName = (str) => {
-  var mapObj = {
-   'Political Action Committee':"PAC",
-   'pac':"PAC",
-   'Pac':"PAC",
-   'political action committee':"PAC",
-   'Association':"Assn.",
-   'Companies':"Co's."
-  };
-
-  var re = new RegExp(Object.keys(mapObj).join("|"),"gi");
-  str = str.replace(re, function(matched){
-    return mapObj[matched];
-  });
-  return str
-}
-
 getPacTweetString = (contribution, cb) => {
   const name = config.congressPerson.name;
   const party = config.congressPerson.party;
   const jurisdiction = config.congressPerson.jurisdiction;
   const handle = config.congressPerson.handle;
-  const committee = contribution.committee.name.toProperCase();
-  const donor = contribution.donor_committee_name.toProperCase();
+  const committee = toProperCase(contribution.committee.name)
+  const donor = toProperCase(contribution.donor_committee_name)
   const abbrevDonor = handleDonorName(donor);
   const loadDate = moment(contribution.load_date).format('YYYY-MM-DD');
   const amount = contribution.contribution_receipt_amount.toLocaleString();
-  const donorDescription = contribution.entity_type_desc.toProperCase();
+  const donorDescription = toProperCase(contribution.entity_type_desc)
   const donorState = contribution.contributor_state;
-  const donorCity = contribution.contributor_city.toProperCase();
+  const donorCity = toProperCase(contribution.contributor_city)
   const pdf = contribution.pdf_url;
   
   bitlyService.shortenUrl(pdf, (err, shortUrl) => {

--- a/app/tweetVote.js
+++ b/app/tweetVote.js
@@ -7,6 +7,7 @@ const twitterService = require('../services/twitter');
 const Vote = require('../models/vote');
 const Contribution = require('../models/contribution');
 
+const handleNullValues = require('../util/helpers').handleNullValues;
 const trimString = require('../util/helpers').trimString; 
 
 module.exports = tweetVote = (cb) => {
@@ -18,6 +19,9 @@ module.exports = tweetVote = (cb) => {
     if (err) {
       return cb(err);
     }
+    // need to handle any null values so string methods don't break
+    handleNullValues(vote.data)
+
     if (!vote) {
       console.log('No votes available to tweet');
       return cb()

--- a/app/tweetVote.js
+++ b/app/tweetVote.js
@@ -7,7 +7,6 @@ const twitterService = require('../services/twitter');
 const Vote = require('../models/vote');
 const Contribution = require('../models/contribution');
 
-const handleNullValues = require('../util/helpers').handleNullValues;
 const trimString = require('../util/helpers').trimString; 
 
 module.exports = tweetVote = (cb) => {
@@ -19,9 +18,6 @@ module.exports = tweetVote = (cb) => {
     if (err) {
       return cb(err);
     }
-    // need to handle any null values so string methods don't break
-    handleNullValues(vote.data)
-
     if (!vote) {
       console.log('No votes available to tweet');
       return cb()

--- a/app/tweetVote.js
+++ b/app/tweetVote.js
@@ -75,7 +75,7 @@ Result: ${result} elected Speaker of the House on ${voteDate}.`;
 
     var handle = config.congressPerson.handle
     var abbreviatedBillQuestion = trimString(vote.question, 25)
-    var abbreviatedBillDescription = trimString(vote.description, 50)
+    var abbreviatedBillDescription = trimString(vote.description, 45)
     var billNumber = vote.bill.number;
     var name = config.congressPerson.name;
     var party = config.congressPerson.party;

--- a/app/tweetVote.js
+++ b/app/tweetVote.js
@@ -1,10 +1,13 @@
 const async = require('async');
+const config = require('../config');
 
 const propublicaService = require('../services/propublica');
-const config = require('../config');
 const twitterService = require('../services/twitter');
+
 const Vote = require('../models/vote');
 const Contribution = require('../models/contribution');
+
+const trimString = require('../util/helpers').trimString; 
 
 module.exports = tweetVote = (cb) => {
   // find oldest vote that has not been tweeted yet
@@ -33,19 +36,6 @@ module.exports = tweetVote = (cb) => {
   });
 
 };
-
-// trim tweet Question & Description without cutting off mid-word
-function trimString(string, maxLength) {
-  var trimmedString = string.substr(0, maxLength);
-  //re-trim if we are in the middle of a word
-  trimmedString = trimmedString.substr(0, Math.min(trimmedString.length, trimmedString.lastIndexOf(" ")))
-  // var lastWord = trimmedString.match(/\w+$/)[0];
-  // var lastIndex = trimmedString.lastIndexOf(" ");
-  // if (lastWord == "of" || lastWord == "the") {
-  //   trimmedString = trimmedString.substring(0, lastIndex);
-  // }
-  return trimmedString;
-}
 
 // Votes tweet 
 const getTweetString = (vote) => {

--- a/services/fec.js
+++ b/services/fec.js
@@ -4,7 +4,7 @@ const config = require('../config');
 exports.getPacContributions = getPacContributions = (cb) => {
 	const options = {
 		method: 'GET',
-		url: `https://api.open.fec.gov/v1/schedules/schedule_a/?api_key=` + config.fec.api_key + `&sort_hide_null=false&sort_nulls_last=true&sort=-contribution_receipt_date&per_page=2&committee_id=` + config.fec.committee_id + `&two_year_transaction_period=2018&is_individual=false`,
+		url: `https://api.open.fec.gov/v1/schedules/schedule_a/?api_key=` + config.fec.api_key + `&sort_hide_null=false&sort_nulls_last=true&sort=-contribution_receipt_date&per_page=100&committee_id=` + config.fec.committee_id + `&two_year_transaction_period=2018&is_individual=false`,
 		json: true
 	}
 

--- a/util/helpers.js
+++ b/util/helpers.js
@@ -1,0 +1,56 @@
+
+// tweeting PAC contributions every 2 hours in tweetPacs
+const okayToTweet = (contribution) => {
+  if (!contribution.tweetedAt) {
+    return true;
+  }
+  const tweetedAt = new moment(contribution.tweetedAt);
+  const cutoff = new moment().subtract(2, 'h');
+    if (tweetedAt.isBefore(cutoff)) {
+      return true;
+    }
+  return false;
+};
+
+// handle null values for string methods
+const handleNullValues = (obj) => {
+  Object.keys(obj).forEach(function(key) {
+    if(obj[key] === null) {
+      obj[key] = '-';
+    }
+  })
+  return obj;
+};
+
+// to avoid 186 errors, abbreviate
+const handleDonorName = (str) => {
+  var mapObj = {
+   'Political Action Committee':"PAC",
+   'pac':"PAC",
+   'Pac':"PAC",
+   'political action committee':"PAC",
+   'Association':"Assn.",
+   'Companies':"Co's."
+  };
+
+  var re = new RegExp(Object.keys(mapObj).join("|"),"gi");
+  str = str.replace(re, function(matched){
+    return mapObj[matched];
+  });
+  return str
+};
+
+// properCase helper -- FEC data is all caps
+const toProperCase = (string) => {
+	return string.replace(/\w\S*/g, (txt) => { 
+		return txt.charAt(0).toUpperCase() + txt.substr(1).toLowerCase();
+	});
+}
+
+module.exports = {
+    okayToTweet: okayToTweet,
+    handleNullValues: handleNullValues,
+    handleDonorName: handleDonorName,
+    toProperCase: toProperCase
+};
+

--- a/util/helpers.js
+++ b/util/helpers.js
@@ -12,28 +12,6 @@ const okayToTweet = (contribution) => {
   return false;
 };
 
-// trim tweet Question & Description without cutting off mid-word
-const trimString = (string, maxLength) => {
-  var trimmedString = string.substr(0, maxLength);
-  //re-trim if we are in the middle of a word
-  if (trimmedString.substr(0) != null) {
-  	trimmedString = trimmedString.substr(0, Math.min(trimmedString.length, trimmedString.lastIndexOf(" ")))
-  	var lastWord = trimmedString.match(/\w+$/)[0];
-  	var lastIndex = trimmedString.lastIndexOf(" ");
-
-		if (lastWord == 'of' ||
-		    lastWord == 'the' ||
-		    lastWord == 'and' ||
-		    lastWord == 'for' ||
-		    lastWord == 'with' ||
-		    lastWord == 'ending') {
-		    trimmedString = trimmedString.substring(0, lastIndex);
-		}
-  	return trimmedString;
-  }
-  return trimmedString
-}
-
 // handle null values for string methods
 const handleNullValues = (obj) => {
   Object.keys(obj).forEach(function(key) {
@@ -43,6 +21,26 @@ const handleNullValues = (obj) => {
   })
   return obj;
 };
+
+// trim tweet Question & Description without cutting off mid-word
+const trimString = (string, maxLength) => {
+  var trimmedString = string.substr(0, maxLength);
+
+  //re-trim if we are in the middle of a word
+  trimmedString = trimmedString.substr(0, Math.min(trimmedString.length, trimmedString.lastIndexOf(" ")))
+  var lastWord = trimmedString.match(/\w+$/)[0];
+  var lastIndex = trimmedString.lastIndexOf(" ");
+
+		if (lastWord == 'of' ||
+		    lastWord == 'the' ||
+		    lastWord == 'and' ||
+		    lastWord == 'for' ||
+		    lastWord == 'with' ||
+		    lastWord == 'ending') {
+		    trimmedString = trimmedString.substring(0, lastIndex);
+		}
+  return trimmedString;
+}
 
 // to avoid 186 errors, abbreviate
 const handleDonorName = (str) => {

--- a/util/helpers.js
+++ b/util/helpers.js
@@ -12,6 +12,22 @@ const okayToTweet = (contribution) => {
   return false;
 };
 
+// trim tweet Question & Description without cutting off mid-word
+const trimString = (string, maxLength) => {
+  var trimmedString = string.substr(0, maxLength);
+  //re-trim if we are in the middle of a word
+  trimmedString = trimmedString.substr(0, Math.min(trimmedString.length, trimmedString.lastIndexOf(" ")))
+  var lastWord = trimmedString.match(/\w+$/)[0];
+  var lastIndex = trimmedString.lastIndexOf(" ");
+  // can this be refactored with a dictionary of these words?
+  if (lastWord == "of" || lastWord == "the" || lastWord == "and" || 
+  	  lastWord == "ending" || lastWord == "or" || lastWord == "for" || 
+  	  lastWord == "with") { 
+    trimmedString = trimmedString.substring(0, lastIndex);
+  }
+  return trimmedString;
+}
+
 // handle null values for string methods
 const handleNullValues = (obj) => {
   Object.keys(obj).forEach(function(key) {
@@ -51,6 +67,7 @@ module.exports = {
     okayToTweet: okayToTweet,
     handleNullValues: handleNullValues,
     handleDonorName: handleDonorName,
-    toProperCase: toProperCase
+    toProperCase: toProperCase,
+    trimString: trimString
 };
 

--- a/util/helpers.js
+++ b/util/helpers.js
@@ -12,6 +12,30 @@ const okayToTweet = (contribution) => {
   return false;
 };
 
+// trim tweet Question & Description 
+const trimString = (string, maxLength) => {
+  var trimmedString = string.substr(0, maxLength);
+  // lastWord regex match will return null if we don't remove punctuation first
+  trimmedString = trimmedString.replace(/\b[-.,()&$#!\[\]{}"']+\B|\B[-.,()&$#!\[\]{}"']+\b/g, "");
+  // now re-trim if we are in the middle of a word
+  trimmedString = trimmedString.substr(0, Math.min(trimmedString.length, trimmedString.lastIndexOf(" ")))
+ 	// remove awkward words at ends of phrases
+  var lastWord = trimmedString.match(/\w+$/)[0];
+  var lastIndex = trimmedString.lastIndexOf(" ");
+
+		if (lastWord == 'of' ||
+		    lastWord == 'the' ||
+		    lastWord == 'and' ||
+		    lastWord == 'for' ||
+		    lastWord == 'with' ||
+		    lastWord == 'to' ||
+		    lastWord == 'to' ||
+		    lastWord == 'ending') {
+		    trimmedString = trimmedString.substring(0, lastIndex);
+		}
+  return trimmedString + `...`; 
+}
+
 // handle null values for string methods
 const handleNullValues = (obj) => {
   Object.keys(obj).forEach(function(key) {
@@ -21,26 +45,6 @@ const handleNullValues = (obj) => {
   })
   return obj;
 };
-
-// trim tweet Question & Description without cutting off mid-word
-const trimString = (string, maxLength) => {
-  var trimmedString = string.substr(0, maxLength);
-
-  //re-trim if we are in the middle of a word
-  trimmedString = trimmedString.substr(0, Math.min(trimmedString.length, trimmedString.lastIndexOf(" ")))
-  var lastWord = trimmedString.match(/\w+$/)[0];
-  var lastIndex = trimmedString.lastIndexOf(" ");
-
-		if (lastWord == 'of' ||
-		    lastWord == 'the' ||
-		    lastWord == 'and' ||
-		    lastWord == 'for' ||
-		    lastWord == 'with' ||
-		    lastWord == 'ending') {
-		    trimmedString = trimmedString.substring(0, lastIndex);
-		}
-  return trimmedString;
-}
 
 // to avoid 186 errors, abbreviate
 const handleDonorName = (str) => {

--- a/util/helpers.js
+++ b/util/helpers.js
@@ -16,16 +16,22 @@ const okayToTweet = (contribution) => {
 const trimString = (string, maxLength) => {
   var trimmedString = string.substr(0, maxLength);
   //re-trim if we are in the middle of a word
-  trimmedString = trimmedString.substr(0, Math.min(trimmedString.length, trimmedString.lastIndexOf(" ")))
-  var lastWord = trimmedString.match(/\w+$/)[0];
-  var lastIndex = trimmedString.lastIndexOf(" ");
-  // can this be refactored with a dictionary of these words?
-  if (lastWord == "of" || lastWord == "the" || lastWord == "and" || 
-  	  lastWord == "ending" || lastWord == "or" || lastWord == "for" || 
-  	  lastWord == "with") { 
-    trimmedString = trimmedString.substring(0, lastIndex);
+  if (trimmedString.substr(0) != null) {
+  	trimmedString = trimmedString.substr(0, Math.min(trimmedString.length, trimmedString.lastIndexOf(" ")))
+  	var lastWord = trimmedString.match(/\w+$/)[0];
+  	var lastIndex = trimmedString.lastIndexOf(" ");
+
+		if (lastWord == 'of' ||
+		    lastWord == 'the' ||
+		    lastWord == 'and' ||
+		    lastWord == 'for' ||
+		    lastWord == 'with' ||
+		    lastWord == 'ending') {
+		    trimmedString = trimmedString.substring(0, lastIndex);
+		}
+  	return trimmedString;
   }
-  return trimmedString;
+  return trimmedString
 }
 
 // handle null values for string methods


### PR DESCRIPTION
✅ moves `okayToTweet`, `trimString`, `handleNullValues`, `handleDonorName`, and `toProperCase` into `utils/helpers.js`
✅ `handleDonorName` deals with long words in PAC donor name like "Association" and some capitalization stuff
✅ `okayToTweet` -- no change -- being used to check if any PAC data from FEC has been tweeted about within 2 hrs
✅ `handleNullValues` is used in PAC tweets since often the donor names/occupation/employer are reported incorrectly and those are `null` and will break the string methods so here we're just converting any `null` value to `'-'`.
✅ We need `toProperCase` bc all of the FEC data is in all caps
✅`trimString` takes a string a number of characters to trim down to, then it trims off anything mid-word, and there's another regex added to remove special characters bc if last char of string is a comma or period it will break. Also removes short words from the ends of phrases to make trimmed string seem more "naturally" abbreviated and adds ellipses.

